### PR TITLE
voce_cached_nav_menu return NULL

### DIFF
--- a/voce-cached-nav.php
+++ b/voce-cached-nav.php
@@ -266,7 +266,8 @@ if ( !class_exists( 'Voce_Cached_Nav' ) ) {
 	}
 
 	function voce_cached_nav_menu( $args ) {
-		Voce_Cached_Nav::menu( $args );
+		return Voce_Cached_Nav::menu( $args );
+        
 	}
 
 }


### PR DESCRIPTION
if trying to use voce_cached_nav_menu to replace wp_nav_menu in my code, I always get NULL value. So, I put return in voce_cached_nav_menu and it's working correctly.

This line in my code that I replace:

$html = '<' . $navtype . $navclass . '>' . wp_nav_menu( $wp_nav ) . '</' . $navtype . '>';

Then I replaced it to:

$html = '<' . $navtype . $navclass . '>' . voce_cached_nav_menu( $wp_nav ) . '</' . $navtype . '>';

and it's just working correctly to print out my nav menu.
