### PR TITLE
If using wrong menu name, it should get default menu instead

### DIFF
--- a/voce-cached-nav.php
+++ b/voce-cached-nav.php
@@ -19,6 +19,7 @@ if ( !class_exists( 'Voce_Cached_Nav' ) ) {
 		const MENUPREFIX = 'wp_nav_menu-';
 		const ITEMSPREFIX = 'wp_nav_items-';
 		const MENUIDS = 'wp_nav_menus';
+		const WP_GET_NAV_MENUS = 'wp_get_nav_menus';
 
 		/**
 		 * Set the action hooks to update the cache
@@ -60,12 +61,13 @@ if ( !class_exists( 'Voce_Cached_Nav' ) ) {
 		}
 
 		public static function get_nav_menus() {
-			$menus = get_transient( self::MENUIDS );
+			$menus = get_transient( self::WP_GET_NAV_MENUS );
 			if ( !is_array( $menus ) ) {
 				$menus = wp_get_nav_menus();
 				foreach ( $menus as $menu ) {
 					self::update_menu_ids_cache( $menu->term_id );
 				}
+				set_transient( self::WP_GET_NAV_MENUS, $menus);
 			}
 			return $menus;
 		}


### PR DESCRIPTION
The fix:
- If using wrong menu name, it should get default menu instead
- cache wp_get_nav_menus
  Have been tested on Wordpress 3.6

I found another bug about when delete the post/trash the post, the cache menu is not cleared properly. I'm going to fix it.
