### PR TITLE
Add 'menu-item-has-children' class to parent items like in nav-menu-template.php

### DIFF
--- a/voce-cached-nav.php
+++ b/voce-cached-nav.php
@@ -246,7 +246,19 @@ if ( !class_exists( 'Voce_Cached_Nav' ) ) {
 			_wp_menu_item_classes_by_context( $menu_items );
 
 			$sorted_menu_items = array();
-			foreach ( (array) $menu_items as $key => $menu_item ) $sorted_menu_items[ $menu_item->menu_order ] = $menu_item;
+			foreach ( (array) $menu_items as $key => $menu_item ) {
+				$sorted_menu_items[ $menu_item->menu_order ] = $menu_item;
+				if ( $menu_item->menu_item_parent )
+					$menu_items_with_children[ $menu_item->menu_item_parent ] = true;
+			}
+		
+			// Add the menu-item-has-children class where applicable
+			if ( $menu_items_with_children ) {
+				foreach ( $sorted_menu_items as &$menu_item ) {
+					if ( isset( $menu_items_with_children[ $menu_item->ID ] ) )
+						$menu_item->classes[] = 'menu-item-has-children';
+				}
+			}
 
 			unset( $menu_items );
 


### PR DESCRIPTION
Add 'menu-item-has-children' class to menu items with children to match the original behavior in wp-includes/nav-menu-template.php so we don't lose any functionality when using as a drop-in-replacement.

Not sure if these classes were left out intentionally, but I don't consider this as a huge performance hit.

Thanks for the great plugin!
